### PR TITLE
Improve macro

### DIFF
--- a/Sources/SQLKitTypingMacros/ColumnMacro.swift
+++ b/Sources/SQLKitTypingMacros/ColumnMacro.swift
@@ -31,7 +31,15 @@ public struct Column: PeerMacro {
         let aliasName = "\(typePrefixString).\(def.typealiasName)"
 
         return [
-            "\(def.modifiers)typealias \(raw: def.columnTypeName) = \(raw: aliasName)",
+            TypeAliasDeclSyntax(
+                leadingTrivia: .docLineComment("/// => \(def.columnType.description)").appending(.newline),
+                modifiers: def.modifiers.trimmed,
+                name: "\(raw: def.columnTypeName)",
+                initializer: TypeInitializerClauseSyntax(
+                    value: "\(raw: aliasName)" as TypeSyntax
+                )
+            ).cast(DeclSyntax.self),
+
             "\(def.modifiers.adding(keyword: .static))let \(def.varIdentifier) = Column<\(raw: aliasName)>(\"\(raw: def.columnName)\")",
         ]
     }

--- a/Sources/SQLKitTypingMacros/SchemaMacro.swift
+++ b/Sources/SQLKitTypingMacros/SchemaMacro.swift
@@ -24,19 +24,14 @@ public struct Schema: MemberAttributeMacro, PeerMacro {
             return []
         }
 
-        var attributes = [
+        return [
+            AttributeSyntax(TypeSyntax("EraseProperty")),
             AttributeSyntax("Column") {
                 LabeledExprSyntax(
                     expression: "\(namedDecl.name.trimmed.text)_types".makeLiteralSyntax()
                 )
             },
         ]
-
-        if declaration.is(EnumDeclSyntax.self) {
-            attributes.append(AttributeSyntax(TypeSyntax("EraseProperty")))
-        }
-
-        return attributes
     }
 
     // MARK: - Peer

--- a/Tests/SQLKitTypingMacroTests/MacroTests.swift
+++ b/Tests/SQLKitTypingMacroTests/MacroTests.swift
@@ -5,9 +5,14 @@ import XCTest
 #if canImport(SQLKitTypingMacros)
 import SQLKitTypingMacros
 
-private let schemaMacro: [String: Macro.Type] = [
+private let allMacro: [String: Macro.Type] = [
     "Schema": Schema.self,
     "Column": Column.self,
+    "EraseProperty": EraseProperty.self,
+]
+
+private let schemaMacro: [String: Macro.Type] = [
+    "Schema": Schema.self,
 ]
 
 final class MacroTests: XCTestCase {
@@ -23,7 +28,12 @@ struct Test {
 """,
 expandedSource: """
 struct Test {
-    var value: Int
+    var value: Int {
+        @available(*, unavailable)
+        get {
+            fatalError()
+        }
+    }
 
     /// => Int
     typealias Value = Test_types.__macro_value
@@ -35,7 +45,7 @@ enum Test_types {
     typealias __macro_value = Int
 }
 """,
-macros: schemaMacro
+macros: allMacro
         )
     }
 
@@ -49,19 +59,17 @@ public struct Test {
 """,
 expandedSource: """
 public struct Test {
+    @EraseProperty @Column("Test_types")
     public var fooBar: Int?
-
-    /// => Int?
-    public typealias FooBar = Test_types.__macro_fooBar
-
-    public static let fooBar = Column<Test_types.__macro_fooBar>("fooBar")
 }
 
 public enum Test_types {
     public typealias __macro_fooBar = Int?
 }
 """,
-macros: schemaMacro
+macros: [
+    "Schema": Schema.self,
+]
         )
     }
 
@@ -121,13 +129,23 @@ struct Test {
 """,
 expandedSource: """
 struct Test {
-    var `class`: Class
+    var `class`: Class {
+        @available(*, unavailable)
+        get {
+            fatalError()
+        }
+    }
 
     /// => Class
     typealias Class = Test_types.__macro_class
 
     static let `class` = Column<Test_types.__macro_class>("class")
-    var `struct`: Int
+    var `struct`: Int {
+        @available(*, unavailable)
+        get {
+            fatalError()
+        }
+    }
 
     /// => Int
     typealias Struct = Test_types.__macro_struct
@@ -140,7 +158,7 @@ enum Test_types {
     typealias __macro_struct = Int
 }
 """,
-macros: schemaMacro
+macros: allMacro
         )
     }
 
@@ -154,7 +172,7 @@ enum Test {
 """,
 expandedSource: """
 enum Test {
-    @Column("Test_types") @EraseProperty
+    @EraseProperty @Column("Test_types")
     var value: Int
 }
 
@@ -162,9 +180,7 @@ enum Test_types {
     typealias __macro_value = Int
 }
 """,
-macros: [
-    "Schema": Schema.self,
-]
+macros: schemaMacro 
         )
     }
 }

--- a/Tests/SQLKitTypingMacroTests/MacroTests.swift
+++ b/Tests/SQLKitTypingMacroTests/MacroTests.swift
@@ -25,6 +25,7 @@ expandedSource: """
 struct Test {
     var value: Int
 
+    /// => Int
     typealias Value = Test_types.__macro_value
 
     static let value = Column<Test_types.__macro_value>("value")
@@ -50,6 +51,7 @@ expandedSource: """
 public struct Test {
     public var fooBar: Int?
 
+    /// => Int?
     public typealias FooBar = Test_types.__macro_fooBar
 
     public static let fooBar = Column<Test_types.__macro_fooBar>("fooBar")
@@ -121,11 +123,13 @@ expandedSource: """
 struct Test {
     var `class`: Class
 
+    /// => Class
     typealias Class = Test_types.__macro_class
 
     static let `class` = Column<Test_types.__macro_class>("class")
     var `struct`: Int
 
+    /// => Int
     typealias Struct = Test_types.__macro_struct
 
     static let `struct` = Column<Test_types.__macro_struct>("struct")


### PR DESCRIPTION
# Add type hint doc comment to macro generated typealias

- before

```swift
typealias Foo = MyTable.__macro_foo
```

- after

```swift
/// => String
typealias Foo = MyTable.__macro_foo
```

This is useful when coding on Xcode and using code completion

# Anytime erase column property

- before

(after `@Schema` evaluated)

```swift
struct MyTable {
    @Column("...")
    var name: String
}
```

- after

```swift
struct MyTable {
    @EraseProprety @Column("...")
    var name: String
}
```

This is because macro will change the property types implicit.
ex:)

```swift
@Schema
struct MyTable {
    var date: Int32
    var createdAt: Date
}
```

this will create `MyTable.Date` type. and `createdAt` propertie's type will be changed to `Int32`.

```swift
    var createdAt: Date // this is Foundation.Date
	↓ after macro evaluated
    var createdAt: Date // this is MyTable.Date → Int32
```