### PR TITLE
@Schema macro add conformance of SchemaProtocol

### DIFF
--- a/Sources/SQLKitTyping/Macros.swift
+++ b/Sources/SQLKitTyping/Macros.swift
@@ -1,7 +1,6 @@
 @_exported import SQLKit
 
 @attached(member, names: arbitrary, named(all), named(__allProperty))
-@attached(memberAttribute)
 @attached(peer, names: suffixed(Types))
 public macro Schema() = #externalMacro(module: "SQLKitTypingMacros", type: "Schema")
 

--- a/Sources/SQLKitTyping/Macros.swift
+++ b/Sources/SQLKitTyping/Macros.swift
@@ -2,6 +2,7 @@
 
 @attached(member, names: arbitrary, named(all), named(__allProperty))
 @attached(peer, names: suffixed(Types))
+@attached(extension, conformances: SchemaProtocol, IDSchemaProtocol)
 public macro Schema() = #externalMacro(module: "SQLKitTypingMacros", type: "Schema")
 
 @attached(accessor)

--- a/Sources/SQLKitTyping/Macros.swift
+++ b/Sources/SQLKitTyping/Macros.swift
@@ -13,12 +13,12 @@ public macro SQLColumnPropertyType(name: String) = #externalMacro(module: "SQLKi
 
 @freestanding(declaration, names: arbitrary)
 public macro hasMany<Schema: SchemaProtocol, T: Equatable>(
-    name: String,
+    propertyName: String,
     mappedBy column: KeyPath<Schema, T>
 ) = #externalMacro(module: "SQLKitTypingMacros", type: "hasMany")
 
 @freestanding(declaration, names: arbitrary)
 public macro hasOne<Model: Decodable & IDSchemaProtocol>(
-    name: String,
+    propertyName: String,
     type: Model.Type
 ) = #externalMacro(module: "SQLKitTypingMacros", type: "hasOne")

--- a/Sources/SQLKitTyping/Schema/SchemaProtocol.swift
+++ b/Sources/SQLKitTyping/Schema/SchemaProtocol.swift
@@ -1,6 +1,6 @@
 import SQLKit
 
-public protocol SchemaProtocol {
+public protocol SchemaProtocol: Codable {
     static var tableName: String { get }
 }
 

--- a/Sources/SQLKitTypingMacros/Macros/Schema.swift
+++ b/Sources/SQLKitTypingMacros/Macros/Schema.swift
@@ -110,6 +110,12 @@ public struct Schema: MemberMacro, PeerMacro, ExtensionMacro {
         conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
+        if declaration.inheritanceClause?.inheritedTypes.contains(where: {
+            $0.type.trimmedDescription.hasSuffix("SchemaProtocol")
+        }) == true {
+            return []
+        }
+
         let hasIDProperty = declaration.memberBlock.members.contains { memberBlockItem in
             let def = ColumnDefinition(
                 decl: memberBlockItem.decl,

--- a/Sources/SQLKitTypingMacros/Macros/Schema.swift
+++ b/Sources/SQLKitTypingMacros/Macros/Schema.swift
@@ -64,45 +64,6 @@ public struct Schema: MemberMacro, MemberAttributeMacro, PeerMacro {
         return result
     }
 
-    // MARK: - MemberAttributeMacro
-
-    public static func expansion(
-        of node: AttributeSyntax,
-        attachedTo declaration: some DeclGroupSyntax,
-        providingAttributesFor member: some DeclSyntaxProtocol,
-        in context: some MacroExpansionContext
-    ) throws -> [AttributeSyntax] {
-        if member.as(VariableDeclSyntax.self)?.attributes.contains(where: {
-            if case .attribute(let attribute) = $0 {
-                return attribute.attributeName.trimmed.description == "Children"
-            }
-            return false
-        }) == true {
-            guard declaration.inheritanceClause?.inheritedTypes.contains(where: {
-                $0.type.trimmed.description == "IDSchemaProtocol"
-            }) == true else {
-                let typeName = declaration.asProtocol((any NamedDeclSyntax).self)?.name.description ?? "this type"
-                throw MessageError("@Children requires \(typeName) to conform to 'IDSchemaProtocol'")
-            }
-            return [
-                AttributeSyntax(TypeSyntax("EraseProperty")),
-            ]
-        }
-
-        if member.as(VariableDeclSyntax.self)?.attributes.contains(where: {
-            if case .attribute(let attribute) = $0 {
-                return attribute.attributeName.trimmed.description == "Parent"
-            }
-            return false
-        }) == true {
-            return [
-                AttributeSyntax(TypeSyntax("EraseProperty")),
-            ]
-        }
-
-        return []
-    }
-
     // MARK: - Peer
 
     public static func expansion(

--- a/Sources/SQLKitTypingMacros/Macros/hasMany.swift
+++ b/Sources/SQLKitTypingMacros/Macros/hasMany.swift
@@ -18,7 +18,7 @@ public struct hasMany: DeclarationMacro {
                 guard let literal else {
                     throw MessageError("StringLiteral expected.")
                 }
-                name = literal
+                propertyName = literal
             case "mappedBy":
                 column = argument.expression.as(KeyPathExprSyntax.self)
             default:

--- a/Sources/SQLKitTypingMacros/Macros/hasMany.swift
+++ b/Sources/SQLKitTypingMacros/Macros/hasMany.swift
@@ -4,16 +4,16 @@ import SwiftSyntaxMacros
 
 public struct hasMany: DeclarationMacro {
     private struct Arguments {
-        var name: String
+        var propertyName: String
         var column: KeyPathExprSyntax
     }
 
     private static func extractArguments(from arguments: LabeledExprListSyntax) throws -> Arguments {
-        var name: String?
+        var propertyName: String?
         var column: KeyPathExprSyntax?
         for argument in arguments {
             switch argument.label?.text {
-            case "name":
+            case "propertyName":
                 let literal = argument.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue
                 guard let literal else {
                     throw MessageError("StringLiteral expected.")
@@ -25,10 +25,10 @@ public struct hasMany: DeclarationMacro {
                 break
             }
         }
-        guard let name, let column else {
+        guard let propertyName, let column else {
             throw MessageError("unexpected.")
         }
-        return .init(name: name, column: column)
+        return .init(propertyName: propertyName, column: column)
     }
 
     // MARK: - Declaration
@@ -39,7 +39,7 @@ public struct hasMany: DeclarationMacro {
     ) throws -> [DeclSyntax] {
         let arguments = try extractArguments(from: node.arguments)
 
-        let name = "\(raw: arguments.name)" as TokenSyntax
+        let name = "\(raw: arguments.propertyName)" as TokenSyntax
         guard let schemaType = arguments.column.root else {
             throw MessageError("Must specify root type.")
         }

--- a/Sources/SQLKitTypingMacros/Macros/hasOne.swift
+++ b/Sources/SQLKitTypingMacros/Macros/hasOne.swift
@@ -18,7 +18,7 @@ public struct hasOne: DeclarationMacro {
                 guard let literal else {
                     throw MessageError("StringLiteral expected.")
                 }
-                name = literal
+                propertyName = literal
             case "type":
                 type = argument.expression.as(MemberAccessExprSyntax.self)
             default:

--- a/Sources/SQLKitTypingMacros/Macros/hasOne.swift
+++ b/Sources/SQLKitTypingMacros/Macros/hasOne.swift
@@ -4,16 +4,16 @@ import SwiftSyntaxMacros
 
 public struct hasOne: DeclarationMacro {
     private struct Arguments {
-        var name: String
+        var propertyName: String
         var type: MemberAccessExprSyntax
     }
 
     private static func extractArguments(from arguments: LabeledExprListSyntax) throws -> Arguments {
-        var name: String?
+        var propertyName: String?
         var type: MemberAccessExprSyntax?
         for argument in arguments {
             switch argument.label?.text {
-            case "name":
+            case "propertyName":
                 let literal = argument.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue
                 guard let literal else {
                     throw MessageError("StringLiteral expected.")
@@ -25,10 +25,10 @@ public struct hasOne: DeclarationMacro {
                 break
             }
         }
-        guard let name, let type else {
+        guard let propertyName, let type else {
             throw MessageError("unexpected.")
         }
-        return .init(name: name, type: type)
+        return .init(propertyName: propertyName, type: type)
     }
 
     // MARK: - Declaration
@@ -39,7 +39,7 @@ public struct hasOne: DeclarationMacro {
     ) throws -> [DeclSyntax] {
         let arguments = try extractArguments(from: node.arguments)
 
-        let name = "\(raw: arguments.name)" as TokenSyntax
+        let name = "\(raw: arguments.propertyName)" as TokenSyntax
         guard let schemaType = arguments.type.base else {
             throw MessageError("Must specify root type.")
         }

--- a/Sources/SQLKitTypingMacros/Util/ColumnDefinition.swift
+++ b/Sources/SQLKitTypingMacros/Util/ColumnDefinition.swift
@@ -26,14 +26,6 @@ struct ColumnDefinition {
         else {
             return nil
         }
-        if varDecl.attributes.contains(where: {
-            if case .attribute(let attribute) = $0 {
-                return ["Children", "Parent"].contains(attribute.attributeName.description)
-            }
-            return false
-        }) {
-            return nil
-        }
 
         guard let binding = varDecl.bindings.first,
               let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier

--- a/Tests/SQLKitTypingMacroTests/MacroClientTests.swift
+++ b/Tests/SQLKitTypingMacroTests/MacroClientTests.swift
@@ -14,12 +14,12 @@ struct RecipeModel: IDSchemaProtocol, Codable, Sendable {
     fileprivate var kcal: Int
 
     #hasMany(
-        name: "ingredients",
+        propertyName: "ingredients",
         mappedBy: \IngredientModel.recipeID
     )
 
     #hasMany(
-        name: "steps",
+        propertyName: "steps",
         mappedBy: \StepModel.recipeID
     )
 }
@@ -31,7 +31,7 @@ struct IngredientModel: SchemaProtocol, Codable, Sendable {
     var recipeID: RecipeID
 
     #hasOne(
-        name: "recipe",
+        propertyName: "recipe",
         type: RecipeModel.self
     )
 
@@ -50,12 +50,12 @@ struct StepModel: SchemaProtocol, Codable, Sendable {
     var photoID: PhotoID?
 
     #hasOne(
-        name: "recipe",
+        propertyName: "recipe",
         type: RecipeModel.self
     )
 
     #hasOne(
-        name: "photo",
+        propertyName: "photo",
         type: PhotoModel.self
     )
 }

--- a/Tests/SQLKitTypingMacroTests/MacroClientTests.swift
+++ b/Tests/SQLKitTypingMacroTests/MacroClientTests.swift
@@ -5,7 +5,7 @@ struct RecipeID: Hashable, Codable, Sendable {}
 struct PhotoID: Hashable, Codable, Sendable {}
 
 @Schema
-struct RecipeModel: IDSchemaProtocol, Codable, Sendable {
+struct RecipeModel: Sendable {
     public static var tableName: String { "recipes" }
 
     var id: RecipeID
@@ -25,7 +25,7 @@ struct RecipeModel: IDSchemaProtocol, Codable, Sendable {
 }
 
 @Schema
-struct IngredientModel: SchemaProtocol, Codable, Sendable {
+struct IngredientModel: Sendable {
     static var tableName: String { "ingredients" }
 
     var recipeID: RecipeID
@@ -40,7 +40,7 @@ struct IngredientModel: SchemaProtocol, Codable, Sendable {
 }
 
 @Schema
-struct StepModel: SchemaProtocol, Codable, Sendable {
+struct StepModel: Sendable {
     static var tableName: String { "steps" }
 
     var recipeID: RecipeID
@@ -61,7 +61,7 @@ struct StepModel: SchemaProtocol, Codable, Sendable {
 }
 
 @Schema
-struct PhotoModel: IDSchemaProtocol, Codable, Sendable {
+struct PhotoModel: Sendable {
     static var tableName: String { "photos" }
 
     var id: PhotoID

--- a/Tests/SQLKitTypingMacroTests/MacroClientTests.swift
+++ b/Tests/SQLKitTypingMacroTests/MacroClientTests.swift
@@ -25,7 +25,7 @@ struct RecipeModel: Sendable {
 }
 
 @Schema
-struct IngredientModel: Sendable {
+struct IngredientModel: SchemaProtocol, Sendable {
     static var tableName: String { "ingredients" }
 
     var recipeID: RecipeID

--- a/Tests/SQLKitTypingMacroTests/MacroTests.swift
+++ b/Tests/SQLKitTypingMacroTests/MacroTests.swift
@@ -279,7 +279,7 @@ enum TestTypes {
     typealias Id = Test.__id.Value
 }
 
-extension Test: SchemaProtocol, IDSchemaProtocol {
+extension Test: IDSchemaProtocol, SchemaProtocol {
 }
 """#,
 macros: schemaMacro

--- a/example/Sources/chinook/Tables.swift
+++ b/example/Sources/chinook/Tables.swift
@@ -2,7 +2,7 @@ import SQLKitTyping
 import Foundation
 
 @Schema
-struct TrackTable: SchemaProtocol, Codable, Sendable {
+struct TrackTable: Sendable {
     static var tableName: String { "tracks" }
 
     var TrackId: Int
@@ -17,7 +17,7 @@ struct TrackTable: SchemaProtocol, Codable, Sendable {
 }
 
 @Schema
-struct AlbumTable: SchemaProtocol, Codable, Sendable {
+struct AlbumTable: Sendable {
     static var tableName: String { "albums" }
 
     var AlbumId: Int
@@ -26,7 +26,7 @@ struct AlbumTable: SchemaProtocol, Codable, Sendable {
 }
 
 @Schema
-struct ArtistTable: SchemaProtocol, Codable, Sendable {
+struct ArtistTable: Sendable {
     static var tableName: String { "artists" }
 
     var ArtistId: Int
@@ -34,7 +34,7 @@ struct ArtistTable: SchemaProtocol, Codable, Sendable {
 }
 
 @Schema
-struct EmployeeTable: SchemaProtocol, Codable, Sendable {
+struct EmployeeTable: Sendable {
     static var tableName: String { "employees" }
 
     var EmployeeId: Int

--- a/example/Sources/school/TestData/TestSchema.swift
+++ b/example/Sources/school/TestData/TestSchema.swift
@@ -4,7 +4,7 @@ import SQLKitTyping
 typealias StudentID = GenericID<Student, UUID>
 
 @Schema
-struct Student: IDSchemaProtocol, Codable, Sendable {
+struct Student: Sendable {
     static var tableName: String { "students" }
 
     var id: StudentID
@@ -15,13 +15,13 @@ struct Student: IDSchemaProtocol, Codable, Sendable {
 typealias SchoolID = GenericID<School, UUID>
 
 @Schema
-struct School: IDSchemaProtocol, Codable, Sendable {
+struct School: Sendable {
     static var tableName: String { "schools" }
 
     var id: SchoolID
     var name: String
 
-    #hasMany(name: "lessons", mappedBy: \Lesson.schoolID)
+    #hasMany(propertyName: "lessons", mappedBy: \Lesson.schoolID)
 }
 
 @Schema
@@ -39,7 +39,7 @@ struct SchoolStudentRelation: RelationSchemaProtocol, Codable, Sendable {
 typealias LessonID = GenericID<Lesson, UUID>
 
 @Schema
-struct Lesson: IDSchemaProtocol, Codable, Sendable {
+struct Lesson: Sendable {
     static var tableName: String { "lessons" }
 
     var id: LessonID


### PR DESCRIPTION
SchemaProtocolにはマクロが生成するコード側でCodableを要求されているので、SchemaProtocol自身にもCodableのrequirementを付与しておく。

また、`@Schema`マクロがSchemaProtocolとIDSchemaProtocolへのconformanceも自動で追加するようにした。
RelationSchemaProtocolのことは忘れていないが、このprotocolが提供する機能が使いづらくそのうち消すかも知れないので、サボっている。